### PR TITLE
Check if configuration file is stored

### DIFF
--- a/PowerTune/MainWindow.xaml.cs
+++ b/PowerTune/MainWindow.xaml.cs
@@ -48,7 +48,7 @@ namespace PowerTune
 
 
             //Load Configuration from settings stored in user profile
-            if (Properties.Settings.Default.ComPort != null && Properties.Settings.Default.BaudRate != null)
+            if (Properties.Settings.Default.ComPort != String.Empty && Properties.Settings.Default.BaudRate != String.Empty)
             {
                 libs.clsComSettings.strSelectCom = Properties.Settings.Default.ComPort;
                 libs.clsComSettings.strSelectedBaud = int.Parse(Properties.Settings.Default.BaudRate);


### PR DESCRIPTION
Replace != null with String.Empty
This fixes errors when settings are empty