### PR TITLE
Ensure we process all the nmea messages

### DIFF
--- a/gps.cpp
+++ b/gps.cpp
@@ -182,10 +182,9 @@ void GPS::readyToRead()
     QByteArray rawData = m_serialport->readAll();          // read data from serial port
     //qDebug()<< "chunk " << rawData;
     line.append(rawData);
-    if (line.contains("\r\n"))
+    while (line.contains("\r\n"))
     {
-        //int end = line.indexOf("\r\n") + 2;
-        int end = line.lastIndexOf("\r\n") + 2;
+        int end = line.indexOf("\r\n") + 2;
         QByteArray message = line;
         //qDebug()<< "line raw" << line;
         message.remove(end, line.length());
@@ -194,7 +193,6 @@ void GPS::readyToRead()
         //qDebug()<< "line new" << line;
         ProcessMessage(message);
     }
-
 
 /*
     for (int i=0; i < rawData.size(); i++)
@@ -218,7 +216,8 @@ void GPS::readyToRead()
 
 
         */
-    }
+}
+
 void GPS::ProcessMessage(QByteArray messageline)
 {
     m_timeouttimer.stop();


### PR DESCRIPTION
Some NMEA receivers can push more than one NMEA message at a time. The previous code
was only parsing one of them. Ensure we split the data received from the serial port
using the newlines characters, and process each message individually.

In the example below, `$GPGGA` was never parsed since `ProcessMessage()` looks at the
headers only to determine what message we received. Since `$GPGGA` was not processed,
the fix status in `processGPGGA()` was not updated, leading to the coordinates updates
to be ignored by the condition on ![line 293](https://github.com/BastianGschrey/PowerTune/blob/164398e0b6eceed4ab92da856115726a4838e161/gps.cpp#L293).

Before :
```
chunk  "$GPRMC,155746.30,A,XXXX.71568,N,XXXXX.34386,W,1.218,,110821,,,A*6E\r\n$GPGGA,155746.30,XXXX.71568,N,XXXXX.34386,W,1,08,1.07,1837.5,M,-21.9,M,,*52\r\n"
line raw "$GPRMC,155746.30,A,XXXX.71568,N,XXXXX.34386,W,1.218,,110821,,,A*6E\r\n$GPGGA,155746.30,XXXX.71568,N,XXXXX.34386,W,1,08,1.07,1837.5,M,-21.9,M,,*52\r\n"
Processed Message "$GPRMC,155746.30,A,XXXX.71568,N,XXXXX.34386,W,1.218,,110821,,,A*6E\r\n$GPGGA,155746.30,XXXX.71568,N,XXXXX.34386,W,1,08,1.07,1837.5,M,-21.9,M,,*52\r\n"
line new ""
```

After :
```
chunk  "$GPRMC,155921.50,A,XXXX.71412,N,XXXXX.33304,W,0.509,,110821,,,A*60\r\n$GPGGA,155921.50,XXXX.71412,N,XXXXX.33304,W,1,08,1.07,1853.4,M,-21.9,M,,*59\r\n"
line raw "$GPRMC,155921.50,A,XXXX.71412,N,XXXXX.33304,W,0.509,,110821,,,A*60\r\n$GPGGA,155921.50,XXXX.71412,N,XXXXX.33304,W,1,08,1.07,1853.4,M,-21.9,M,,*59\r\n"
Processed Message "$GPRMC,155921.50,A,XXXX.71412,N,XXXXX.33304,W,0.509,,110821,,,A*60\r\n"
line new "$GPGGA,155921.50,XXXX.71412,N,XXXXX.33304,W,1,08,1.07,1853.4,M,-21.9,M,,*59\r\n"
line raw "$GPGGA,155921.50,XXXX.71412,N,XXXXX.33304,W,1,08,1.07,1853.4,M,-21.9,M,,*59\r\n"
Processed Message "$GPGGA,155921.50,XXXX.71412,N,XXXXX.33304,W,1,08,1.07,1853.4,M,-21.9,M,,*59\r\n"
line new ""
```